### PR TITLE
Standard api

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,53 @@ and it is highly recommended to read the Mimi documentation first to
 understand the code structure. For starter code on running the model just once,
 see the code in the file `examples/main.jl`.
 
+The basic way to access a copy of the default MimiRICE2010 model is the following:
+```
+using MimiRICE2010
+
+m = MimiRICE2010.get_model()
+run(m)
+```
+
+## Calculating the Social Cost of Carbon
+
+Here is an example of computing the social cost of carbon with MimiRICE2010. Note that the units of the returned value are dollars $/ton CO2.
+```
+using Mimi
+using MimiRICE2010
+
+# Get the social cost of carbon in year 2015 from the default MimiRICE2010 model:
+scc = MimiRICE2010.compute_scc(year = 2015)
+
+# You can also compute the SCC from a modified version of a MimiRICE2010 model:
+m = MimiRICE2010.get_model()    # Get the default version of the MimiRICE2010 model
+update_param!(m, :t2xco2, 5)    # Try a higher climate sensitivity value
+scc = MimiRICE2010.compute_scc(m, year=2015)    # compute the scc from the modified model by passing it as the first argument to compute_scc
+```
+The first argument to the `compute_scc` function is a MimiRICE2010 model, and it is an optional argument. If no model is provided, the default MimiRICE2010 model will be used. 
+There are also other keyword arguments available to `compute_scc`. Note that the user must specify a `year` for the SCC calculation, but the rest of the keyword arguments have default values.
+```
+compute_scc(m = get_model(),  # if no model provided, will use the default MimiRICE2010 model
+    year = nothing,  # user must specify an emission year for the SCC calculation
+    last_year = 2595,  # the last year to run and use for the SCC calculation. Default is the last year of the time dimension, 2595.
+    prtp = 0.03,  # pure rate of time preference parameter used for constant discounting
+)
+```
+There is an additional function for computing the SCC that also returns the MarginalModel that was used to compute it. It returns these two values as a NamedTuple of the form (scc=scc, mm=mm). The same keyword arguments from the `compute_scc` function are available for the `compute_scc_mm` function. Example:
+```
+using Mimi
+using MimiRICE2010
+
+result = MimiRICE2010.compute_scc_mm(year=2025, last_year=2295, prtp=0.025)
+
+result.scc  # returns the computed SCC value
+
+result.mm   # returns the Mimi MarginalModel
+
+marginal_temp = result.mm[:climatedynamics, :TATM]  # marginal results from the marginal model can be accessed like this
+```
+
+
 ## Known issues
 
 * Atmospheric CO2 concentrations in the years 2005 and 2015 are fixed in

--- a/examples/main.jl
+++ b/examples/main.jl
@@ -1,7 +1,7 @@
 using Mimi
 using MimiRICE2010
 
-m = getrice()
+m = get_model()
 run(m)
 
 explore(m)

--- a/src/MimiRICE2010.jl
+++ b/src/MimiRICE2010.jl
@@ -19,10 +19,12 @@ include("components/welfare_component.jl")
 
 export constructrice, getrice
 
+const model_years = 2005:10:2595
+
 function constructrice(p)
 
     m = Model()
-    set_dimension!(m, :time, 2005:10:2595)
+    set_dimension!(m, :time, model_years)
     set_dimension!(m, :regions, ["US", "EU", "Japan", "Russia", "Eurasia", "China", "India", "MidEast", "Africa", "LatAm", "OHI", "OthAsia"])
 
     add_comp!(m, grosseconomy, :grosseconomy)
@@ -155,12 +157,14 @@ function constructrice(p)
     return m
 end #function
 
-function getrice(;datafile=joinpath(@__DIR__, "..", "data", "RICE_2010_base_000.xlsm"))
+function get_model(;datafile=joinpath(@__DIR__, "..", "data", "RICE_2010_base_000.xlsm"))
     params = getrice2010parameters(datafile)
 
     m = constructrice(params)
 
     return m
 end #function
+
+getrice = get_model     # Maintain the old `getrice` function name in addition to the standard MimiRICE2010.get_model
 
 end #module

--- a/src/components/co2cycle_component.jl
+++ b/src/components/co2cycle_component.jl
@@ -4,7 +4,7 @@
     MU = Variable(index=[time]) # Carbon concentration increase in shallow oceans (GtC from 1750)
     ML = Variable(index=[time]) # Carbon concentration increase in lower oceans (GtC from 1750)
 
-    E = Parameter(index=[time]) # Total CO2 emissions (GtCO2 per year)
+    E = Parameter(index=[time]) # Total CO2 emissions (GtC per year)
     mat0 = Parameter() # Initial Concentration in atmosphere 2010 (GtC)
     mat1 = Parameter()
     mu0 = Parameter() # Initial Concentration in upper strata 2010 (GtC)

--- a/src/components/emissions_component.jl
+++ b/src/components/emissions_component.jl
@@ -1,8 +1,8 @@
 @defcomp emissions begin
     regions = Index()
 
-    E = Variable(index=[time]) # Total CO2 emissions (GtCO2 per year)
-    EIND = Variable(index=[time, regions]) # Industrial emissions (GtCO2 per year)
+    E = Variable(index=[time]) # Total CO2 emissions (GtC per year)
+    EIND = Variable(index=[time, regions]) # Industrial emissions (GtC per year)
     CCA = Variable(index=[time]) # Cumulative indiustrial emissions
     ABATECOST = Variable(index=[time, regions]) # Cost of emissions reductions  (trillions 2005 USD per year)
     MCABATE = Variable(index=[time, regions]) # Marginal cost of abatement (2005$ per ton CO2)

--- a/src/marginaldamage.jl
+++ b/src/marginaldamage.jl
@@ -1,6 +1,89 @@
+"""
+compute_scc(m::Model=get_model(); year::Int = nothing, last_year::Int = 2595), prtp::Float64 = 0.03)
+
+Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiRICE2010 model. 
+If no model is provided, the default model from MimiRICE2010.get_model() is used.
+Constant discounting is used from the specified pure rate of time preference `prtp`.
+"""
+function compute_scc(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = model_years[end], prtp::Float64 = 0.03)
+    year === nothing ? error("Must specify an emission year. Try `compute_scc(m, year=2015)`.") : nothing
+    !(last_year in model_years) ? error("Invlaid value of $last_year for last_year. last_year must be within the model's time index $model_years.") : nothing
+    !(year in model_years[1]:10:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index $(model_years[1]):10:$last_year.") : nothing
+
+    mm = get_marginal_model(m; year = year)
+
+    return _compute_scc(mm, year=year, last_year=last_year, prtp=prtp)
+end
+
+"""
+compute_scc_mm(m::Model=get_model(); year::Int = nothing, last_year::Int = 2595, prtp::Float64 = 0.03)
+
+Returns a NamedTuple (scc=scc, mm=mm) of the social cost of carbon and the MarginalModel used to compute it.
+Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiRICE2010 model. 
+If no model is provided, the default model from MimiRICE2010.get_model() is used.
+Constant discounting is used from the specified pure rate of time preference `prtp`.
+"""
+function compute_scc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = model_years[end], prtp::Float64 = 0.03)
+    year === nothing ? error("Must specify an emission year. Try `compute_scc_mm(m, year=2015)`.") : nothing
+    !(last_year in model_years) ? error("Invlaid value of $last_year for last_year. last_year must be within the model's time index $model_years.") : nothing
+    !(year in model_years[1]:10:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index $(model_years[1]):10:$last_year.") : nothing
+
+    mm = get_marginal_model(m; year = year)
+    scc = _compute_scc(mm; year=year, last_year=last_year, prtp=prtp)
+    
+    return (scc = scc, mm = mm)
+end
+
+# helper function for computing SCC from a MarginalModel, not to be exported or advertised to users
+function _compute_scc(mm::MarginalModel; year::Int, last_year::Int, prtp::Float64)
+    ntimesteps = findfirst(isequal(last_year), model_years)     # Will run through the timestep of the specified last_year 
+    run(mm, ntimesteps=ntimesteps)
+
+    marginal_damages = -1 * mm[:neteconomy, :C][1:ntimesteps, :] * 10^12 * 12/44 # convert from trillion $/ton C to $/ton CO2; multiply by -1 to get positive value for damages
+    global_marginal_damages = dropdims(sum(marginal_damages, dims = 2), dims=2)
+
+    df = [zeros(length(model_years[1]:10:year)-1)..., [1/(1+prtp)^(t-year) for t in year:10:last_year]...]
+    scc = sum(df .* marginal_damages * 10)  # currently implemented as a 10year step function; so each timestep of discounted marginal damages is multiplied by 10
+    return scc
+end
+
+"""
+get_marginal_model(m::Model = get_model(); year::Int = nothing)
+
+Creates a Mimi MarginalModel where the provided m is the base model, and the marginal model has additional emissions of CO2 in year `year`.
+If no Model m is provided, the default model from MimiDICE2010.get_model() is used as the base model.
+"""
+function get_marginal_model(m::Model=get_model(); year::Union{Int, Nothing} = nothing)
+    year === nothing ? error("Must specify an emission year. Try `get_marginal_model(m, year=2015)`.") : nothing
+    !(year in model_years) ? error("Cannot add marginal emissions in $year, year must be within the model's time index $(model_years[1]):10:$last_year.") : nothing
+
+    mm = create_marginal_model(m, 1e10) # Pulse has a value of 1GtC per year for ten years
+    add_marginal_emissions!(mm.marginal, year)
+
+    return mm
+end
+
+"""
+Adds a marginal emission component to year m which adds 1Gt of additional C emissions per year for ten years starting in the specified `year`.
+"""
+function add_marginal_emissions!(m::Model, year::Int) 
+    add_comp!(m, Mimi.adder, :marginalemission, before=:co2cycle)
+
+    time = Mimi.dimension(m, :time)
+    addem = zeros(length(time))
+    addem[time[year]] = 1.0     # 1 GtC per year for ten years
+
+    set_param!(m, :marginalemission, :add, addem)
+    connect_param!(m, :marginalemission, :input, :emissions, :E)
+    connect_param!(m, :co2cycle, :E, :marginalemission, :output)
+end
+
+
+# OLD previously used marginal damages functions
+
 function getmarginal_rice_models(;emissionyear=2005,datafile=joinpath(@__DIR__, "..", "data", "RICE_2010_base_000.xlsm"))
    
-    RICE = getrice()
+    RICE = get_model()
     run(RICE)
 
     mm = MarginalModel(RICE)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -124,4 +124,40 @@ end #for loop
 
 end #mimi-rice-2010-integration testset
 
+@testset "Standard API functions" begin 
+
+m = MimiRICE2010.get_model()
+run(m)
+
+# Test the errors
+@test_throws ErrorException MimiRICE2010.compute_scc()  # test that it errors if you don't specify a year
+@test_throws ErrorException MimiRICE2010.compute_scc(year=2020)  # test that it errors if the year isn't in the time index
+@test_throws ErrorException MimiRICE2010.compute_scc(last_year=2300)  # test that it errors if the last_year isn't in the time index
+@test_throws ErrorException MimiRICE2010.compute_scc(year=2105, last_year=2100)  # test that it errors if the year is after last_year
+
+# Test the SCC 
+scc1 = MimiRICE2010.compute_scc(year=2015)
+@test scc1 isa Float64
+
+# Test that it's smaller with a shorter horizon
+scc2 = MimiRICE2010.compute_scc(year=2015, last_year=2295)
+@test scc2 < scc1
+
+# Test that it's larger with a smalle prtp
+scc3 = MimiRICE2010.compute_scc(year=2015, last_year=2295, prtp=0.02)
+@test scc3 > scc2
+
+# Test with a modified model 
+m = MimiRICE2010.get_model()
+update_param!(m, :t2xco2, 5)    
+scc4 = MimiRICE2010.compute_scc(m, year=2015)
+@test scc4 > scc1   # Test that a higher value of climate sensitivty makes the SCC bigger
+
+# Test compute_scc_mm
+result = MimiRICE2010.compute_scc_mm(year=2035)
+@test result.scc isa Float64
+@test result.mm isa Mimi.MarginalModel
+
+end
+
 end #mimi-rice-2010 testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using Mimi
 using DataFrames
 using CSVFiles
 
-m = getrice()
+m = MimiRICE2010.get_model()
 run(m)
 
 parameter_filename = joinpath(@__DIR__, "..", "data", "RICE_2010_base_000.xlsm")


### PR DESCRIPTION
- I changed the comments in the emissions and co2cycle components to say GtC instead of GtCO2 (I think this is correct and that it should match the units of MimiDICE2010)
- all of the SCC code is identical to MimiDICE2010, except that marginal damages have to be summed across regions to get a global value
